### PR TITLE
Upgrade-to-node-14.18.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ The purpose of this example is to provide details as to how one would go about u
 
 - Docker Desktop 4.1.1 or newer
 
-- Node 14.18.1 or newer
+- Node 14.18.2 or newer
 
 - PostgreSQL 14.0 or newer
 
 - Rails 6.1.4.1 or newer
 
-- Ruby 3.0.2 or newer
+- Ruby 3.1.0 or newer
 
 Note: This tutorial was updated on macOS 11.6.1. Docker Desktop is ony needed if you're following the `Docker Installation`.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The purpose of this example is to provide details as to how one would go about u
 
 - Rails 6.1.4.1 or newer
 
-- Ruby 3.1.0 or newer
+- Ruby 3.0.2 or newer
 
 Note: This tutorial was updated on macOS 11.6.1. Docker Desktop is ony needed if you're following the `Docker Installation`.
 


### PR DESCRIPTION
This PR supports the following features:

- upgrade to Node  14.18.2
- revert to Ruby 3.0.2