### PR TITLE
Refresh Ruby gems.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '3.1.0'
 
-gem 'rails',                    '~> 7.0.0'
+gem 'rails',                    '~> 7.0.1'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap',                 '>= 1.9.3', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,8 +67,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     bindex (0.8.1)
-    bootsnap (1.9.3)
-      msgpack (~> 1.0)
+    bootsnap (1.10.2)
+      msgpack (~> 1.2)
     builder (3.2.4)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
@@ -83,8 +83,8 @@ GEM
     graphiql-rails (1.8.0)
       railties
       sprockets-rails
-    graphql (1.13.4)
-    i18n (1.8.11)
+    graphql (1.13.7)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
     io-wait (0.2.1)
@@ -100,7 +100,7 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.7.1)
     minitest (5.15.0)
-    msgpack (1.4.2)
+    msgpack (1.4.4)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -117,11 +117,11 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.0)
+    nokogiri (1.13.1)
       mini_portile2 (~> 2.7.0)
       racc (~> 1.4)
-    pg (1.2.3)
-    puma (5.5.2)
+    pg (1.3.0)
+    puma (5.6.1)
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
@@ -160,15 +160,15 @@ GEM
     rake (13.0.6)
     reline (0.3.1)
       io-console (~> 0.5)
-    rspec-core (3.10.1)
+    rspec-core (3.10.2)
       rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.1)
+    rspec-expectations (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.2)
+    rspec-mocks (3.10.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-rails (5.0.2)
+    rspec-rails (5.0.3)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       railties (>= 5.2)
@@ -197,7 +197,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.5.3)
+    zeitwerk (2.5.4)
 
 PLATFORMS
   ruby
@@ -211,7 +211,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-cors (~> 1.0)
   rack-mini-profiler (~> 2.3, >= 2.3.3)
-  rails (~> 7.0.0)
+  rails (~> 7.0.1)
   rspec-rails (~> 5.0.2)
   sprockets-rails (~> 3.4, >= 3.4.2)
   tzinfo-data


### PR DESCRIPTION
This PR supports the following features:

- upgrade to Rails 7.0.1

- refresh Ruby gems