### PR TITLE
Refresh Ruby gems and bump Node to the latest stable release.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     bindex (0.8.1)
-    bootsnap (1.10.2)
+    bootsnap (1.10.3)
       msgpack (~> 1.2)
     builder (3.2.4)
     concurrent-ruby (1.1.9)
@@ -83,7 +83,7 @@ GEM
     graphiql-rails (1.8.0)
       railties
       sprockets-rails
-    graphql (1.13.7)
+    graphql (1.13.8)
     i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
@@ -120,7 +120,7 @@ GEM
     nokogiri (1.13.1)
       mini_portile2 (~> 2.7.0)
       racc (~> 1.4)
-    pg (1.3.0)
+    pg (1.3.1)
     puma (5.6.1)
       nio4r (~> 2.0)
     racc (1.6.0)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The purpose of this example is to provide details as to how one would go about u
 
 - Docker Desktop 4.4.2 or newer
 
-- Node 14.18.2 or newer
+- Node 14.18.3 or newer
 
 - PostgreSQL 14.1 or newer
 


### PR DESCRIPTION
This PR supports the following features:

- refresh Ruby gems

- upgrade to Node 14.18.3
