### PR TITLE
Bump from graphql 2.0.12 to 2.0.13.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rails',                    '~> 7.0', '>= 7.0.3'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap',                 '~> 1.11', '>= 1.11.1', require: false
 
-gem 'graphql',                  '~> 2.0', '>= 2.0.9'
+gem 'graphql',                  '~> 2.0', '>= 2.0.13'
 
 gem 'pg',                       '~> 1.3', '>= 1.3.5'
 gem 'puma',                     '~> 5.6', '>= 5.6.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     graphiql-rails (1.8.0)
       railties
       sprockets-rails
-    graphql (2.0.12)
+    graphql (2.0.13)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
@@ -208,7 +208,7 @@ DEPENDENCIES
   bootsnap (~> 1.11, >= 1.11.1)
   debug (~> 1.5.0)
   graphiql-rails (~> 1.8.0)
-  graphql (~> 2.0, >= 2.0.9)
+  graphql (~> 2.0, >= 2.0.13)
   pg (~> 1.3, >= 1.3.5)
   puma (~> 5.6, >= 5.6.4)
   rack-cors (~> 1.1, >= 1.1.1)


### PR DESCRIPTION
This PR supports the following features:

- bump graphql from 2.0.12 to 2.0.13
