### PR TITLE
Update to GraphQL 2.3.0 and refresh other Ruby gems.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rails',                    '~> 7.1.3.2'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap',                 '~> 1.11', '>= 1.11.1', require: false
 
-gem 'graphql',                  '~> 2.2', '>= 2.2.5'
+gem 'graphql',                  '~> 2.3'
 
 gem 'pg',                       '~> 1.3', '>= 1.3.5'
 gem 'puma',                     '~> 6.4', '>= 6.4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
       mutex_m
       tzinfo (~> 2.0)
     base64 (0.2.0)
-    bigdecimal (3.1.6)
+    bigdecimal (3.1.7)
     bindex (0.8.1)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
@@ -96,12 +96,12 @@ GEM
     graphiql-rails (1.8.0)
       railties
       sprockets-rails
-    graphql (2.2.11)
+    graphql (2.3.0)
       base64
-    i18n (1.14.1)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
-    irb (1.11.2)
+    irb (1.12.0)
       rdoc
       reline (>= 0.4.2)
     loofah (2.22.0)
@@ -114,7 +114,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     mini_mime (1.1.5)
-    minitest (5.22.2)
+    minitest (5.22.3)
     msgpack (1.7.2)
     mutex_m (0.2.0)
     net-imap (0.4.10)
@@ -126,12 +126,12 @@ GEM
       timeout
     net-smtp (0.4.0.1)
       net-protocol
-    nio4r (2.7.0)
-    nokogiri (1.16.2-aarch64-linux)
+    nio4r (2.7.1)
+    nokogiri (1.16.3-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.16.2-arm64-darwin)
+    nokogiri (1.16.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.2-x86_64-darwin)
+    nokogiri (1.16.3-x86_64-darwin)
       racc (~> 1.4)
     pg (1.5.6)
     psych (5.1.2)
@@ -139,7 +139,7 @@ GEM
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
-    rack (3.0.9.1)
+    rack (3.0.10)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
     rack-mini-profiler (3.0.0)
@@ -181,7 +181,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.1.0)
-    rdoc (6.6.2)
+    rdoc (6.6.3.1)
       psych (>= 4.0.0)
     reline (0.4.3)
       io-console (~> 0.5)
@@ -237,7 +237,7 @@ DEPENDENCIES
   bootsnap (~> 1.11, >= 1.11.1)
   debug (~> 1.5.0)
   graphiql-rails (~> 1.8.0)
-  graphql (~> 2.2, >= 2.2.5)
+  graphql (~> 2.3)
   pg (~> 1.3, >= 1.3.5)
   puma (~> 6.4, >= 6.4.2)
   rack-cors (~> 1.1, >= 1.1.1)

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ The purpose of this example is to provide details as to how one would go about u
 
 ## Software requirements
 
-- Docker Desktop 4.16.2 or newer
+- Docker Desktop 4.28.0 or newer
 
-- PostgreSQL 15.5 or newer
+- PostgreSQL 15.6 or newer
 
 - Rails 7.1.3.2 or newer
 
 - Ruby 3.3.0 or newer
 
-Note: This tutorial was updated on macOS 14.3.1. Docker Desktop is ony needed if you're following the `Docker Installation`.
+Note: This tutorial was updated on macOS 14.4. Docker Desktop is ony needed if you're following the `Docker Installation`.
 
 ## Communication
 
@@ -310,7 +310,7 @@ Note: This tutorial was updated on macOS 14.3.1. Docker Desktop is ony needed if
 17. add `graphql` Ruby gem to your `Gemfile` dependencies as follows:
 
     ```zsh
-    bundle add graphql
+    bundle add graphql --version '~> 2.3'
     ```
 
 18. configure the graphql dependencies for our application


### PR DESCRIPTION
This PR supports the following features:

- update to GraphQL 2.3.0 and refresh other Ruby gems.