### PR TITLE
Update to GraphQL 2.3.18.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rails',                    '~> 7.1.3.4'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap',                 '~> 1.11', '>= 1.11.1', require: false
 
-gem 'graphql',                  '~> 2.3.15'
+gem 'graphql',                  '~> 2.3.18'
 
 gem 'pg',                       '~> 1.3', '>= 1.3.5'
 gem 'puma',                     '~> 6.4', '>= 6.4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     graphiql-rails (1.8.0)
       railties
       sprockets-rails
-    graphql (2.3.17)
+    graphql (2.3.18)
       base64
       fiber-storage
     i18n (1.14.6)
@@ -240,7 +240,7 @@ DEPENDENCIES
   bootsnap (~> 1.11, >= 1.11.1)
   debug (~> 1.5.0)
   graphiql-rails (~> 1.8.0)
-  graphql (~> 2.3.15)
+  graphql (~> 2.3.18)
   pg (~> 1.3, >= 1.3.5)
   puma (~> 6.4, >= 6.4.2)
   rack-cors (~> 1.1, >= 1.1.1)


### PR DESCRIPTION
This PR supports the following features:

- update to GraphQL 2.3.18.